### PR TITLE
Added methods for homogenization + testing for homogeneous

### DIFF
--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1840,6 +1840,45 @@ macro_rules! vec_impl_spatial_4d {
                 pub fn back_point_lh   () -> Self where T: Zero + One + Neg<Output=T> { Self::new(T::zero(), T::zero(), -T::one(), T::one()) }
                 /// Get the homogeneous point vector which has `z` set to 1 ("back" in a right-handed coordinate system).
                 pub fn back_point_rh   () -> Self where T: Zero + One {  Self::unit_z_point() }
+
+                /// Get a copy of this vector where each component has been divided in order to
+                /// make `w = 1`.
+                ///
+                /// More info: A homogeneous point has `w = 1`. Some operations (e.g. projection)
+                /// can cause this to no longer be the case. Homogenization is when you divide
+                /// every component of the vector by `w`. This makes `w = 1` and the remaining
+                /// components are also appropriately scaled. This process is also called
+                /// "normalization" in some textbooks, but that name is already taken by
+                /// other methods of this struct.
+                ///
+                /// If `w = 0`, this method will result in a division by zero. Be careful!
+                pub fn homogenized(self) -> Self where T: Div<Output=T>, T: Copy {
+                    self / self.w
+                }
+                /// Divide the vector's components such that `w = 1`.
+                ///
+                /// See the `homogenized` method for more information.
+                pub fn homogenize(&mut self) where T: Div<Output=T>, T: Copy {
+                    *self = self.homogenized();
+                }
+                /// Returns true if this vector is homogeneous (`w = 0` or `w = 1`).
+                ///
+                /// Uses `ApproxEq`.
+                pub fn is_homogeneous(self) -> bool where T: ApproxEq + Zero + One + Copy {
+                    self.is_homogeneous_point() || self.is_homogeneous_vector()
+                }
+                /// Returns true if this vector is a homogeneous point (`w = 1`).
+                ///
+                /// Uses `ApproxEq`.
+                pub fn is_homogeneous_point(self) -> bool where T: ApproxEq + One {
+                    self.w.relative_eq(&T::one(), T::default_epsilon(), T::default_max_relative())
+                }
+                /// Returns true if this vector is a homogeneous vector (`w = 0`).
+                ///
+                /// Uses `ApproxEq`.
+                pub fn is_homogeneous_vector(self) -> bool where T: ApproxEq + Zero {
+                    self.w.relative_eq(&T::zero(), T::default_epsilon(), T::default_max_relative())
+                }
             }
         )+
     }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1870,13 +1870,13 @@ macro_rules! vec_impl_spatial_4d {
                 /// Returns true if this vector is a homogeneous point (`w = 1`).
                 ///
                 /// Uses `ApproxEq`.
-                pub fn is_homogeneous_point(self) -> bool where T: ApproxEq + One {
+                pub fn is_point(self) -> bool where T: ApproxEq + One {
                     self.w.relative_eq(&T::one(), T::default_epsilon(), T::default_max_relative())
                 }
-                /// Returns true if this vector is a homogeneous vector (`w = 0`).
+                /// Returns true if this vector is a homogeneous direction (`w = 0`).
                 ///
                 /// Uses `ApproxEq`.
-                pub fn is_homogeneous_vector(self) -> bool where T: ApproxEq + Zero {
+                pub fn is_direction(self) -> bool where T: ApproxEq + Zero {
                     self.w.relative_eq(&T::zero(), T::default_epsilon(), T::default_max_relative())
                 }
             }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1865,7 +1865,7 @@ macro_rules! vec_impl_spatial_4d {
                 ///
                 /// Uses `ApproxEq`.
                 pub fn is_homogeneous(self) -> bool where T: ApproxEq + Zero + One + Copy {
-                    self.is_homogeneous_point() || self.is_homogeneous_vector()
+                    self.is_point() || self.is_direction()
                 }
                 /// Returns true if this vector is a homogeneous point (`w = 1`).
                 ///


### PR DESCRIPTION
Thanks again for a great library! I decided to add on to #29 by adding some methods I've wanted on `Vec4` for homogenization.

You're probably familiar with this, but just in case: homogenization is when you divide all the components of the vector by `w` in order to get a homogeneous point with `w = 1`. This usually happens in the graphics pipeline right after projection. 

The process is called `normalization` in some texts, but that name is obviously already taken by the `normalized` and `normalize` methods.

This PR adds the methods:

* `homogenized` - return a copy of the vector with all the components divided by `w`
* `homogenize` - divide all the components by `w` in place
* `is_homogeneous` - test for either `w = 1` or `w = 0`
* `is_homogeneous_point` - test for `w = 1`
* `is_homogeneous_vector` - test for `w = 0`

It doesn't make sense to have this for anything other than `Vec4`, so I added it to the `vec_impl_spatial_4d` macro.

All the methods are documented. I based the documentation off the `normalize`, `normalized`, and `is_normalized` methods.

![image](https://user-images.githubusercontent.com/530939/60854291-b0515a80-a1cd-11e9-86a2-cefb7e2d3179.png)
