### PR TITLE
Prototype `mint` conversions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ num-integer = "~0.1.35"
 static_assertions = "~0.2.5"
 image = { version = "~0.17", optional = true, default-features = false }
 serde = { version = "~1.0.24", optional = true, features = ["derive"] }
+mint = { version = "~0.5.1", optional = true }
 # clippy = { version = "0.0.166", optional = true }
 
 [target.'cfg(any(target_arch="x86", target_arch="x86_64"))'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,14 +3,14 @@
 //! See [the wiki](https://github.com/yoanlcq/vek/wiki) for an overview, FAQ, guides, and other info.
 //!
 //! This crate is still in its beta days!
-//! The public API is quite close to being stable, but it hasn't been battle-tested enough.  
+//! The public API is quite close to being stable, but it hasn't been battle-tested enough.
 //! Issues and bug reports are very welcome!
 //!
 //! # Cargo features
 //!
 //! - `vec8`, `vec16`, `vec32`, `vec64`, `rgba`, `rgb`, `uvw`, `uv`
 //!   Enable these types.
-//!   Other types are always enabled for the sake of doc-tests.  
+//!   Other types are always enabled for the sake of doc-tests.
 //! - `repr_simd` enables Nightly Rust's `repr_simd` and `simd_ffi` features, and unlock
 //!   SIMD versions of all appropriate types (though `repr_simd` modules).
 //!   On Stable, this feature has no effect.
@@ -55,6 +55,9 @@ extern crate serde;
 
 #[cfg(feature = "x86intrin")]
 extern crate x86intrin;
+
+#[cfg(feature = "mint")]
+extern crate mint;
 
 extern crate num_integer;
 extern crate num_traits;

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -2593,6 +2593,21 @@ macro_rules! vec_impl_mat2_via_vec4 {
 }
 
 
+#[cfg(feature = "mint")]
+macro_rules! vec_impl_mint {
+    ($Vec:ident, $mintVec: ident) => {
+        use mint::$mintVec;
+        impl<T> From<$mintVec<T>> for $Vec<T>
+        where
+            T: Copy + Default,
+        {
+            fn from(v: $mintVec<T>) -> $Vec<T> {
+                $Vec::from_slice(&v.as_ref()[..])
+
+            }
+        }
+     };
+ }
 
 /// Calls `vec_impl_vec!{}` on each appropriate vector type.
 macro_rules! vec_impl_all_vecs {
@@ -2610,6 +2625,9 @@ macro_rules! vec_impl_all_vecs {
             vec_impl_vec!($c_or_simd struct Vec2   vec2      (2) ("({}, {})") (x y) (x y) (0 1) (T,T));
             vec_impl_spatial!(Vec2);
             vec_impl_spatial_2d!(Vec2);
+            #[cfg(feature = "mint")]
+            vec_impl_mint!(Vec2, Vector2);
+
 
             impl<T> Vec2<T> {
                 /// Returns a copy of this vector, with X and Y swapped.

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -2596,13 +2596,21 @@ macro_rules! vec_impl_mat2_via_vec4 {
 #[cfg(feature = "mint")]
 macro_rules! vec_impl_mint {
     ($Vec:ident, $mintVec: ident) => {
-        use mint::$mintVec;
-        impl<T> From<$mintVec<T>> for $Vec<T>
+        impl<T> From<mint::$mintVec<T>> for $Vec<T>
         where
             T: Copy + Default,
         {
-            fn from(v: $mintVec<T>) -> $Vec<T> {
+            fn from(v: mint::$mintVec<T>) -> $Vec<T> {
                 $Vec::from_slice(&v.as_ref()[..])
+
+            }
+        }
+        impl<T> Into<mint::$mintVec<T>> for $Vec<T>
+        where
+            T: Copy + Default,
+        {
+            fn into(self) -> mint::$mintVec<T> {
+                mint::$mintVec::<T>::from_slice(self.as_slice())
 
             }
         }
@@ -2667,6 +2675,8 @@ macro_rules! vec_impl_all_vecs {
             vec_impl_vec!($c_or_simd struct Vec3     vec3     (3) ("({}, {}, {})") (x y z) (x y z) (0 1 2) (T,T,T));
             vec_impl_spatial!(Vec3);
             vec_impl_spatial_3d!(Vec3);
+            #[cfg(feature = "mint")]
+            vec_impl_mint!(Vec3, Vector3);
 
             impl<T> Vec3<T> {
                 /// Returns a copy of this vector, with X and Z swapped.
@@ -2733,6 +2743,8 @@ macro_rules! vec_impl_all_vecs {
             vec_impl_spatial_4d!(Vec4);
             vec_impl_shuffle_4d!(Vec4 (x y z w));
             vec_impl_mat2_via_vec4!(Vec4);
+            #[cfg(feature = "mint")]
+            vec_impl_mint!(Vec4, Vector4);
 
             impl<T> Vec4<T> {
                 /// Returns a copy of this vector, with elements reversed.


### PR DESCRIPTION
After almost a year I got around to trying to add conversions to/from `mint` types, a la #18 .  Currently this is just for basic vector types, since I want some feedback to see if I'm doing this semi-appropriately before I go through and try to do the same with all the other types.  Notably, I can't add unit tests for the conversions 'cause they would need to know which `mint` equivalent types to convert to and from.

Let me know if I should keep going with this!