### PR TITLE
Mint interop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ num-integer = "~0.1.35"
 static_assertions = "~0.2.5"
 image = { version = "~0.17", optional = true, default-features = false }
 serde = { version = "~1.0.24", optional = true, features = ["derive"] }
+mint = { version = "~0.5.1", optional = true }
 # clippy = { version = "0.0.166", optional = true }
 
 [target.'cfg(any(target_arch="x86", target_arch="x86_64"))'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,9 @@ extern crate serde;
 #[cfg(feature = "x86intrin")]
 extern crate x86intrin;
 
+#[cfg(feature = "mint")]
+extern crate mint;
+
 extern crate num_integer;
 extern crate num_traits;
 // NOTE: Allow unused imports here, because usage depends on which features are enabled.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@
 //! - `x86intrin` enables x86 intrinsics through the `x86intrin` crate. `vek` doesn't directly
 //!   depend on it because it won't compile on Stable and there's no way (as of this writing)
 //!   to selectively depend on a crate based on the `rustc` version, not even via build scripts.
+//! - `mint` enables conversion to the `mint` crate's types.
+//!   `mint` is an interoperability layer for math libraries.
 //!
 //! # `#![no_std]`
 //! This crate is `#![no_std]`.

--- a/src/mat.rs
+++ b/src/mat.rs
@@ -32,7 +32,6 @@ macro_rules! mat_impl_mat {
 
         use super::column_major::$Mat as Transpose;
 
-        // FIXME: Move elsewhere
         #[cfg(feature = "mint")]
         impl<T> From<mint::$MintRowMat<T>> for $Mat<T> {
             fn from(m: mint::$MintRowMat<T>) -> Self {
@@ -550,7 +549,6 @@ macro_rules! mat_impl_mat {
 
         use super::row_major::$Mat as Transpose;
 
-        // FIXME: Move elsewhere
         #[cfg(feature = "mint")]
         impl<T> From<mint::$MintColMat<T>> for $Mat<T> {
             fn from(m: mint::$MintColMat<T>) -> Self {

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -418,6 +418,22 @@ macro_rules! quaternion_complete_mod {
                 self.into()
             }
         }
+
+        #[cfg(feature = "mint")]
+        impl<T> From<mint::Quaternion<T>> for Quaternion<T> {
+            fn from(q: mint::Quaternion<T>) -> Self {
+                let mint::Quaternion { s, v } = q;
+                Self::from_scalar_and_vec3((s, v))
+            }
+        }
+
+        #[cfg(feature = "mint")]
+        impl<T> Into<mint::Quaternion<T>> for Quaternion<T> {
+            fn into(self) -> mint::Quaternion<T> {
+                let (s, v) = self.into_scalar_and_vec3();
+                mint::Quaternion { s, v: v.into() }
+            }
+        }
         
         /// The `Lerp` implementation for quaternion is the "Normalized LERP".
         impl<T, Factor> Lerp<Factor> for Quaternion<T>

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -2626,6 +2626,7 @@ macro_rules! vec_impl_all_vecs {
             pub struct Vec2<T> { pub x:T, pub y:T }
             vec_impl_vec!($c_or_simd struct Vec2   vec2      (2) ("({}, {})") (x y) (x y) (0 1) (T,T));
             vec_impl_mint!(Vec2, Vector2, (x y));
+            vec_impl_mint!(Vec2, Point2, (x y));
             vec_impl_spatial!(Vec2);
             vec_impl_spatial_2d!(Vec2);
 
@@ -2666,6 +2667,7 @@ macro_rules! vec_impl_all_vecs {
             pub struct Vec3<T> { pub x:T, pub y:T, pub z:T }
             vec_impl_vec!($c_or_simd struct Vec3     vec3     (3) ("({}, {}, {})") (x y z) (x y z) (0 1 2) (T,T,T));
             vec_impl_mint!(Vec3, Vector3, (x y z));
+            vec_impl_mint!(Vec3, Point3, (x y z));
             vec_impl_spatial!(Vec3);
             vec_impl_spatial_3d!(Vec3);
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -2593,6 +2593,23 @@ macro_rules! vec_impl_mat2_via_vec4 {
 }
 
 
+macro_rules! vec_impl_mint {
+    ($Vec:ident, $mintVec: ident, ($($namedget:ident)+)) => {
+        #[cfg(feature = "mint")]
+        impl<T> From<mint::$mintVec<T>> for $Vec<T> {
+            fn from(v: mint::$mintVec<T>) -> Self {
+                Self { $($namedget : v.$namedget),+ }
+            }
+        }
+
+        #[cfg(feature = "mint")]
+        impl<T> Into<mint::$mintVec<T>> for $Vec<T> {
+            fn into(self) -> mint::$mintVec<T> {
+                mint::$mintVec { $($namedget : self.$namedget),+ }
+            }
+        }
+    };
+}
 
 /// Calls `vec_impl_vec!{}` on each appropriate vector type.
 macro_rules! vec_impl_all_vecs {
@@ -2608,6 +2625,7 @@ macro_rules! vec_impl_all_vecs {
             $(#[$repr_attrs])+
             pub struct Vec2<T> { pub x:T, pub y:T }
             vec_impl_vec!($c_or_simd struct Vec2   vec2      (2) ("({}, {})") (x y) (x y) (0 1) (T,T));
+            vec_impl_mint!(Vec2, Vector2, (x y));
             vec_impl_spatial!(Vec2);
             vec_impl_spatial_2d!(Vec2);
 
@@ -2647,6 +2665,7 @@ macro_rules! vec_impl_all_vecs {
             $(#[$repr_attrs])+
             pub struct Vec3<T> { pub x:T, pub y:T, pub z:T }
             vec_impl_vec!($c_or_simd struct Vec3     vec3     (3) ("({}, {}, {})") (x y z) (x y z) (0 1 2) (T,T,T));
+            vec_impl_mint!(Vec3, Vector3, (x y z));
             vec_impl_spatial!(Vec3);
             vec_impl_spatial_3d!(Vec3);
 
@@ -2711,6 +2730,7 @@ macro_rules! vec_impl_all_vecs {
                 pub w: T
             }
             vec_impl_vec!($c_or_simd struct Vec4   vec4    (4) ("({}, {}, {}, {})") (x y z w) (x y z w) (0 1 2 3) (T,T,T,T));
+            vec_impl_mint!(Vec4, Vector4, (x y z w));
             vec_impl_spatial!(Vec4);
             vec_impl_spatial_4d!(Vec4);
             vec_impl_shuffle_4d!(Vec4 (x y z w));


### PR DESCRIPTION
Based on the initial work from #37. Hopefully fixes #18.

Waiting for your approval @icefoxen but of course, feedback from anyone else is appreciated!

So... This implements `mint` type conversions for `vek`'s types. Here is a list of what has NOT been done:
- Conversions to non-square matrices (e.g `mint::RowMatrix2x3`), which I feel would add too much noise to the codebase. `mint` could actually implement such conversions between its own types.
- Conversion from `Quaternion` to `mint::EulerAngles`. I also think `mint` could implement the conversion itself, if anybody really needs it??
- Unit tests, because these conversions are trivial.

There is one thing that's ticking me: `mint` says that their quaternion type corresponds to a right-handed matrix. I might be mistaken, but it doesn't make sense to me; A quaternion has no assumed "handedness", the handedness is that of the application.

Put another way: The result of quaternion multiplication is defined by that of the cross product, which doesn't care about handedness: `cross((1,0,0), (0,1,0)) == (0,0,1)` regardless of whether your `Z` goes "forward" or "backwards" in your application.

I was asking myself "uh, so, are my quaternions actually right-handed? Am I not breaking an invariant in mint by just passing the unchanged scalar and vector part?", so if it turns out the question doesn't make sense, I won't need to worry.

Thanks in advance!

(by the way @icefoxen don't forget to add yourself to the list of contributors, if you feel like it. For all intents and purposes, you did contribute.)