### PR TITLE
Fix `is_normalized` sometimes returning false for normalized vectors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.10.0" # remember to update html_root_url in src/lib.rs
-authors = ["Yoan Lecoq <yoanlecoq.io@gmail.com>", "Joshua Barretto <joshua.s.barretto@gmail.com>", "Sunjay Varma <varma.sunjay@gmail.com>", "timokoesters <timo@koesters.xyz>"]
+authors = ["Yoan Lecoq <yoanlecoq.io@gmail.com>", "Joshua Barretto <joshua.s.barretto@gmail.com>", "Sunjay Varma <varma.sunjay@gmail.com>", "timokoesters <timo@koesters.xyz>", "Imbris <imbrisf@gmail.com>"]
 description = "Generic 2D-3D math swiss army knife for game engines, with SIMD support and focus on convenience."
 documentation = "https://docs.rs/vek"
 keywords = ["vector", "matrix", "simd", "quaternion", "bezier"]

--- a/README.md
+++ b/README.md
@@ -32,3 +32,4 @@ If you plan to work a pull request, please file an issue first so that we can ag
 - Joshua Barretto (GitHub: [@zesterer](https://github.com/zesterer))
 - Sunjay Varma (GitHub : [@sunjay](https://github.com/sunjay))
 - Timo Kösters (GitHub : [@timokoesters](https://github.com/timokoesters))
+- Imbris (Github: [@imberflur](https://github.com/imberflur))


### PR DESCRIPTION
Calling `is_normalized` on normalized vecs can return `false`  
I suspect this is due to using `magnitude_squared` and it seems like the most efficient method to solve this is doubling the epsilon.
I implemented that and it has worked for me so far.
```rust
[src/main.rs:12] vek::Vec3::<f32>::new(-30.988623, -19.13624, 17.503609) = Vec3 {
    x: -30.988623,
    y: -19.13624,
    z: 17.503609,
}
[src/main.rs:13] unnormalized.normalized() = Vec3 {
    x: -0.766879,
    y: -0.47356677,
    z: 0.43316385,
}
[src/main.rs:14] normalized.is_normalized() = false
[src/main.rs:15] normalized.magnitude() = 0.9999999
[src/main.rs:16] normalized.magnitude() + std::f32::EPSILON = 1.0
[src/main.rs:17] normalized.magnitude_squared() = 0.99999976
[src/main.rs:18] normalized.magnitude_squared() + std::f32::EPSILON * 2.0 = 1.0
```
