### PR TITLE
Re-export column_major matrix module from self

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,4 @@ If you plan to work a pull request, please file an issue first so that we can ag
 - Sunjay Varma (GitHub : [@sunjay](https://github.com/sunjay))
 - Timo Kösters (GitHub : [@timokoesters](https://github.com/timokoesters))
 - Imbris (Github: [@imberflur](https://github.com/imberflur))
+- Lukas Wirth (Github: [@veykril](https://github.com/veykril))

--- a/src/mat.rs
+++ b/src/mat.rs
@@ -4013,7 +4013,7 @@ macro_rules! mat_declare_modules {
         /// Rationale:
         /// - (Matrix * Vector) multiplications are more efficient;
         /// - This is the layout expected by OpenGL;
-        pub use crate::column_major::*;
+        pub use self::column_major::*;
     }
 }
 


### PR DESCRIPTION
Turns out that `vek::mat::repr_simd::Mat3` becomes `repr_c` instead due to an incorrect re-export definition.