### PR TITLE
reenable caret versions instead of tilde versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,14 +50,14 @@ std = ["num-traits/std", "serde/std"]
 libm = ["num-traits/libm"]
 
 [build-dependencies]
-rustc_version = "~0.2.3"
+rustc_version = "0.2.3"
 
 [dependencies]
-approx = { version = "~0.3.2", default-features = false }
-num-traits = { version = "~0.2.11", default-features = false }
-num-integer = { version = "~0.1.42", default-features = false }
-static_assertions = "~1.1.0"
-image = { version = "~0.17", optional = true, default-features = false }
-serde = { version = "~1.0.105", optional = true, default-features = false, features = ["derive"] }
-mint = { version = "~0.5.4", optional = true }
+approx = { version = "0.3.2", default-features = false }
+num-traits = { version = "0.2.11", default-features = false }
+num-integer = { version = "0.1.42", default-features = false }
+static_assertions = "1.1.0"
+image = { version = "0.17", optional = true, default-features = false }
+serde = { version = "1.0.105", optional = true, default-features = false, features = ["derive"] }
+mint = { version = "0.5.4", optional = true }
 # clippy = { version = "0.0.166", optional = true }


### PR DESCRIPTION
- this commit basically reverts:
  https://github.com/yoanlcq/vek/commit/855bc9b6efca7cf99c27960122775c303baed2f4
- semver is the standart in rust and it could be assumed that crates follow this for their dependencies.
- especially in larger projects, having tilde dependencies increases the list of dependencies and duplicate versions.
- even though vek frequently updates those, switching to caret version (at least for most crates) should be sufficient

Hi, i haven't found the reason why vek switched to tilde back in 2017, but maybe returning back to caret version might be a good thing