### PR TITLE
Remove example that was never UB

### DIFF
--- a/src/mat.rs
+++ b/src/mat.rs
@@ -1530,33 +1530,24 @@ macro_rules! mat_impl_mat4 {
             /// Returns a memberwise-converted copy of this matrix, using `AsPrimitive`.
             ///
             /// # Examples
-            /// 
+            ///
             /// ```
             /// # use vek::vec::Vec4;
             /// let v = Vec4::new(0_f32, 1., 2., 3.);
             /// let i: Vec4<i32> = v.as_();
             /// assert_eq!(i, Vec4::new(0, 1, 2, 3));
             /// ```
-            /// 
+            ///
             /// # Safety
             ///
             /// **In Rust versions before 1.45.0**, some uses of the `as` operator were not entirely safe.
-            /// In particular, it was undefined behavior if:
-            ///
-            /// - A truncated floating point value cannot fit in the target integer
-            ///   type ([#10184](https://github.com/rust-lang/rust/issues/10184));
+            /// In particular, it was undefined behavior if
+            /// a truncated floating point value could not fit in the target integer
+            /// type ([#10184](https://github.com/rust-lang/rust/issues/10184));
             ///
             /// ```ignore
             /// # use num_traits::AsPrimitive;
             /// let x: u8 = (1.04E+17).as_(); // UB
-            /// ```
-            ///
-            /// - Or a floating point value does not fit in another floating
-            ///   point type ([#15536](https://github.com/rust-lang/rust/issues/15536)).
-            ///
-            /// ```ignore
-            /// # use num_traits::AsPrimitive;
-            /// let x: f32 = (1e300f64).as_(); // UB
             /// ```
             pub fn as_<D>(self) -> Mat4<D> where T: AsPrimitive<D>, D: 'static + Copy {
                 let m = self.$lines;
@@ -3295,33 +3286,24 @@ macro_rules! mat_impl_mat3 {
             /// Returns a memberwise-converted copy of this matrix, using `AsPrimitive`.
             ///
             /// # Examples
-            /// 
+            ///
             /// ```
             /// # use vek::vec::Vec4;
             /// let v = Vec4::new(0_f32, 1., 2., 3.);
             /// let i: Vec4<i32> = v.as_();
             /// assert_eq!(i, Vec4::new(0, 1, 2, 3));
             /// ```
-            /// 
+            ///
             /// # Safety
             ///
             /// **In Rust versions before 1.45.0**, some uses of the `as` operator were not entirely safe.
-            /// In particular, it was undefined behavior if:
-            ///
-            /// - A truncated floating point value cannot fit in the target integer
-            ///   type ([#10184](https://github.com/rust-lang/rust/issues/10184));
+            /// In particular, it was undefined behavior if
+            /// a truncated floating point value could not fit in the target integer
+            /// type ([#10184](https://github.com/rust-lang/rust/issues/10184));
             ///
             /// ```ignore
             /// # use num_traits::AsPrimitive;
             /// let x: u8 = (1.04E+17).as_(); // UB
-            /// ```
-            ///
-            /// - Or a floating point value does not fit in another floating
-            ///   point type ([#15536](https://github.com/rust-lang/rust/issues/15536)).
-            ///
-            /// ```ignore
-            /// # use num_traits::AsPrimitive;
-            /// let x: f32 = (1e300f64).as_(); // UB
             /// ```
             pub fn as_<D>(self) -> Mat3<D> where T: AsPrimitive<D>, D: 'static + Copy {
                 let m = self.$lines;
@@ -3818,33 +3800,24 @@ macro_rules! mat_impl_mat2 {
             /// Returns a memberwise-converted copy of this matrix, using `AsPrimitive`.
             ///
             /// # Examples
-            /// 
+            ///
             /// ```
             /// # use vek::vec::Vec4;
             /// let v = Vec4::new(0_f32, 1., 2., 3.);
             /// let i: Vec4<i32> = v.as_();
             /// assert_eq!(i, Vec4::new(0, 1, 2, 3));
             /// ```
-            /// 
+            ///
             /// # Safety
             ///
             /// **In Rust versions before 1.45.0**, some uses of the `as` operator were not entirely safe.
-            /// In particular, it was undefined behavior if:
-            ///
-            /// - A truncated floating point value cannot fit in the target integer
-            ///   type ([#10184](https://github.com/rust-lang/rust/issues/10184));
+            /// In particular, it was undefined behavior if
+            /// a truncated floating point value could not fit in the target integer
+            /// type ([#10184](https://github.com/rust-lang/rust/issues/10184));
             ///
             /// ```ignore
             /// # use num_traits::AsPrimitive;
             /// let x: u8 = (1.04E+17).as_(); // UB
-            /// ```
-            ///
-            /// - Or a floating point value does not fit in another floating
-            ///   point type ([#15536](https://github.com/rust-lang/rust/issues/15536)).
-            ///
-            /// ```ignore
-            /// # use num_traits::AsPrimitive;
-            /// let x: f32 = (1e300f64).as_(); // UB
             /// ```
             pub fn as_<D>(self) -> Mat2<D> where T: AsPrimitive<D>, D: 'static + Copy {
                 let m = self.$lines;

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -580,33 +580,24 @@ macro_rules! vec_impl_vec {
             /// Returns a memberwise-converted copy of this vector, using `AsPrimitive`.
             ///
             /// # Examples
-            /// 
+            ///
             /// ```
             /// # use vek::vec::Vec4;
             /// let v = Vec4::new(0_f32, 1., 2., 3.);
             /// let i: Vec4<i32> = v.as_();
             /// assert_eq!(i, Vec4::new(0, 1, 2, 3));
             /// ```
-            /// 
+            ///
             /// # Safety
             ///
             /// **In Rust versions before 1.45.0**, some uses of the `as` operator were not entirely safe.
-            /// In particular, it was undefined behavior if:
-            ///
-            /// - A truncated floating point value cannot fit in the target integer
-            ///   type ([#10184](https://github.com/rust-lang/rust/issues/10184));
+            /// In particular, it was undefined behavior if
+            /// a truncated floating point value could not fit in the target integer
+            /// type ([#10184](https://github.com/rust-lang/rust/issues/10184));
             ///
             /// ```ignore
             /// # use num_traits::AsPrimitive;
             /// let x: u8 = (1.04E+17).as_(); // UB
-            /// ```
-            ///
-            /// - Or a floating point value does not fit in another floating
-            ///   point type ([#15536](https://github.com/rust-lang/rust/issues/15536)).
-            ///
-            /// ```ignore
-            /// # use num_traits::AsPrimitive;
-            /// let x: f32 = (1e300f64).as_(); // UB
             /// ```
             #[inline]
             pub fn as_<D>(self) -> $Vec<D> where T: AsPrimitive<D>, D: 'static + Copy {


### PR DESCRIPTION
As discussed in https://github.com/rust-num/num-traits/pull/184 , the second example was never UB. I am now updating vek docs to match num-traits.

Closes #59 