### PR TITLE
Added with_z and with_w methods

### DIFF
--- a/src/vec.rs
+++ b/src/vec.rs
@@ -2791,6 +2791,10 @@ macro_rules! vec_impl_all_vecs {
                     let Self { x, y } = self;
                     Self { x: y, y: x }
                 }
+                /// Add a Z component to this vector such that it becomes a Vec3.
+                pub fn with_z(self, z: T) -> Vec3<T> {
+                    Vec3::new(self.x, self.y, z)
+                }
             }
 
             impl<T> From<Vec3<T>> for Vec2<T> {
@@ -2835,6 +2839,10 @@ macro_rules! vec_impl_all_vecs {
                 /// Same as Vec2::from(self), but shorter.
                 pub fn xy(self) -> Vec2<T> {
                     self.into()
+                }
+                /// Add a W component to this vector such that it becomes a Vec4.
+                pub fn with_w(self, w: T) -> Vec4<T> {
+                    Vec4::new(self.x, self.y, self.z, w)
                 }
             }
 


### PR DESCRIPTION
I've found that I frequently need to take a 2D vector and take it into 3D, but with a non-zero z component.

My current strategy looks something like `Vec3::<i32>::from(my_vec2) + Vec3::unit_z() * z`. Needless to say, this is unwieldy and additionally requires specifying the type such that the compiler knows which `From` impl to use.

This PR adds a `with_z` and `with_w` method to `Vec2` and `Vec2` respectively which streamlines this process.

The above example simply becomes `my_vec2.with_z(z)`.

I've added `with_w` for completeness.