### PR TITLE
CI: add GitHub Actions workflow

### DIFF
--- a/.github/workflows/on_push_and_prs.yml
+++ b/.github/workflows/on_push_and_prs.yml
@@ -1,0 +1,194 @@
+on: [push, pull_request]
+
+
+name: build-and-test
+
+jobs:
+  aarch64-glibc:
+    name: Ubuntu 18.04 (for ARMv8 - glibc)
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-unknown-linux-gnu
+          override: true
+
+      - name: Install binutils-arm-none-eabi
+        run: |
+          sudo apt-get update
+          sudo apt-get install binutils-aarch64-linux-gnu
+      
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: check
+          args: --target=aarch64-unknown-linux-gnu
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: test
+          args: --target=aarch64-unknown-linux-gnu
+
+  armv7-glibc:
+    name: Ubuntu 18.04 (for ARMv7 - glibc)
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: armv7-unknown-linux-gnueabihf
+          override: true
+
+      - name: Install binutils-arm-none-eabi
+        run: |
+          sudo apt-get update
+          sudo apt-get install binutils-arm-none-eabi
+      
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: check
+          args: --target=armv7-unknown-linux-gnueabihf
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: test
+          args: --target=armv7-unknown-linux-gnueabihf
+
+          
+  x86_64_musl:
+    name: Ubuntu 20.04 (musl)
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-unknown-linux-musl
+          override: true
+
+      - name: Install dependencies for musl libc
+        run: |
+          sudo apt-get update
+          sudo apt-get install musl-tools
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --target x86_64-unknown-linux-musl
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --target x86_64-unknown-linux-musl
+          
+  x86_64_glibc:
+    name: Ubuntu 18.04 (glibc)
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  macos:
+    name: macOS
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  windows-msvc:
+    name: Windows (MSVC)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+
+  windows-mingw:
+    name: Windows (MinGW)
+    runs-on: windows-2019
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-pc-windows-gnu
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --target x86_64-pc-windows-gnu
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --target x86_64-pc-windows-gnu


### PR DESCRIPTION
Closes #74 

This GitHub Actions workflow will run `cargo check` and `cargo test` on Linux (x86-64 with musl, x86-64 with glibc, armv7, armv8), macOS and Windows (MinGW and MSVC).

Let me know if there's something else you want GH Actions to do