### PR TITLE
Remove unused dependency `static_assertions`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,6 @@ rustc_version = "0.4"
 approx = { version = "0.5.0", default-features = false }
 num-traits = { version = "0.2.14", default-features = false }
 num-integer = { version = "0.1.44", default-features = false }
-static_assertions = "1.1.0"
 image = { version = "0.23", optional = true, default-features = false }
 serde = { version = "1.0.105", optional = true, default-features = false, features = ["derive"] }
 mint = { version = "0.5.4", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,10 +69,6 @@ pub extern crate num_traits;
 #[macro_use]
 pub extern crate approx;
 
-#[allow(unused_imports)]
-#[macro_use]
-extern crate static_assertions;
-
 #[cfg(feature = "platform_intrinsics")]
 mod simd_llvm;
 // ^ Please do not make this module public; we don't want people to use it, because it could change as the SIMD infrastructure evolves.


### PR DESCRIPTION
The macros are no longer used anywhere in the code.
I tested both building with all features and running the tests.