### PR TITLE
Add optional `az` dependency, implement its traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,3 +61,4 @@ serde = { version = "1.0.105", optional = true, default-features = false, featur
 mint = { version = "0.5.4", optional = true }
 bytemuck = { version = "1.7.2", optional = true }
 # clippy = { version = "0.0.166", optional = true }
+az = { version = "1.1", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.15.9" # remember to update html_root_url in src/lib.rs
-authors = ["Yoan Lecoq <yoanlecoq.io@gmail.com>", "Joshua Barretto <joshua.s.barretto@gmail.com>", "Sunjay Varma <varma.sunjay@gmail.com>", "timokoesters <timo@koesters.xyz>", "Imbris <imbrisf@gmail.com>"]
+authors = ["Yoan Lecoq <yoanlecoq.io@gmail.com>", "Joshua Barretto <joshua.s.barretto@gmail.com>", "Sunjay Varma <varma.sunjay@gmail.com>", "timokoesters <timo@koesters.xyz>", "Imbris <imbrisf@gmail.com>", "Patiga <dev@patiga.eu>"]
 description = "Generic 2D-3D math swiss army knife for game engines, with SIMD support and focus on convenience."
 documentation = "https://docs.rs/vek"
 keywords = ["vector", "matrix", "simd", "quaternion", "bezier"]

--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ If you plan to work a pull request, please file an issue first so that we can ag
 - Imbris (GitHub: [@imberflur](https://github.com/imberflur))
 - Lukas Wirth (GitHub: [@veykril](https://github.com/veykril))
 - Martin Taibr (GitHub: [@martin-t](https://github.com/martin-t))
+- Patiga (GitHub: [@Patiga](https://github.com/Patiga))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,9 @@ pub extern crate mint;
 #[cfg(feature = "bytemuck")]
 pub extern crate bytemuck;
 
+#[cfg(feature = "az")]
+pub extern crate az;
+
 pub extern crate num_integer;
 pub extern crate num_traits;
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1917,6 +1917,43 @@ macro_rules! vec_impl_vec {
         unsafe impl<T> bytemuck::Pod for $Vec<T> where T: bytemuck::Pod {
             // Nothing here
         }
+
+        #[cfg(feature = "az")]
+        mod impl_az {
+            use super::$Vec;
+
+            impl<T, U> az::Cast<$Vec<U>> for $Vec<T> where T: az::Cast<U> {
+                fn cast(self) -> $Vec<U> {
+                    $Vec::new($( self.$get.cast() ),*)
+                }
+            }
+            impl<T, U> az::CheckedCast<$Vec<U>> for $Vec<T> where T: az::CheckedCast<U> {
+                fn checked_cast(self) -> Option<$Vec<U>> {
+                    Some($Vec::new($( self.$get.checked_cast()? ),*))
+                }
+            }
+            impl<T, U> az::SaturatingCast<$Vec<U>> for $Vec<T> where T: az::SaturatingCast<U> {
+                fn saturating_cast(self) -> $Vec<U> {
+                    $Vec::new($( self.$get.saturating_cast() ),*)
+                }
+            }
+            impl<T, U> az::WrappingCast<$Vec<U>> for $Vec<T> where T: az::WrappingCast<U> {
+                fn wrapping_cast(self) -> $Vec<U> {
+                    $Vec::new($( self.$get.wrapping_cast() ),*)
+                }
+            }
+            impl<T, U> az::OverflowingCast<$Vec<U>> for $Vec<T> where T: az::OverflowingCast<U> {
+                fn overflowing_cast(self) -> ($Vec<U>, bool) {
+                    $(let $get = self.$get.overflowing_cast();)*
+                    ($Vec::new($( $get.0 ),*), $($get.1)||*)
+                }
+            }
+            impl<T, U> az::UnwrappedCast<$Vec<U>> for $Vec<T> where T: az::UnwrappedCast<U> {
+                fn unwrapped_cast(self) -> $Vec<U> {
+                    $Vec::new($( self.$get.unwrapped_cast() ),*)
+                }
+            }
+        }
     };
 }
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1285,6 +1285,45 @@ macro_rules! vec_impl_vec {
             }
         }
 
+        // Implement az conversion methods
+        #[cfg(feature = "az")]
+        impl<T> $Vec<T> {
+                /// Casts the components similar to `as`.
+                ///
+                /// **Panics**
+                /// - In debug mode if the value does not fit in the target type
+                /// - If the value does not fit and can't be wrapped, for example `f32::INFINITY`
+                pub fn az<U>(self) -> $Vec<U> where T: az::Cast<U> {
+                    az::Cast::cast(self)
+                }
+                /// Casts the components, but returns `None` if the value does not fit in the target type.
+                pub fn checked_as<U>(self) -> Option<$Vec<U>> where T: az::CheckedCast<U> {
+                    az::CheckedCast::checked_cast(self)
+                }
+                /// Cast the components, uses `MIN` and `MAX` if the value does not fit in the target type.
+                pub fn saturating_as<U>(self) -> $Vec<U> where T: az::SaturatingCast<U> {
+                    az::SaturatingCast::saturating_cast(self)
+                }
+                /// Cast the components and wraps if the value does not fit in the target type.
+                ///
+                /// **Panics**
+                /// - If the value does not fit and can't be wrapped, for example `f32::INFINITY`
+                pub fn wrapping_as<U>(self) -> $Vec<U> where T: az::WrappingCast<U> {
+                    az::WrappingCast::wrapping_cast(self)
+                }
+                /// Cast the components and wraps if the value does not fit in the target type.
+                /// Returns an additional `bool` to indicate if a value has wrapped.
+                ///
+                /// **Panics**
+                /// - If the value does not fit and can't be wrapped, for example `f32::INFINITY`
+                pub fn overflowing_as<U>(self) -> ($Vec<U>, bool) where T: az::OverflowingCast<U> {
+                    az::OverflowingCast::overflowing_cast(self)
+                }
+                /// Cast the components and **panics** if the value does not fit in the target type.
+                pub fn unwrapped_as<U>(self) -> $Vec<U> where T: az::UnwrappedCast<U> {
+                    az::UnwrappedCast::unwrapped_cast(self)
+                }
+            }
 
         // OPS
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -3713,6 +3713,18 @@ pub use self::repr_c::*;
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "az")]
+    #[test]
+    fn test_az() {
+        let err = crate::Vec2::new(u16::MAX as u32 + 3, 21);
+        let ok = crate::Vec2::new(0, u16::MAX as u32);
+        assert!(err.checked_as::<u16>().is_none());
+        assert!(ok.checked_as::<u16>().is_some());
+        assert_eq!(err.wrapping_as::<u16>(), crate::Vec2::new(2, 21));
+        assert_eq!(err.saturating_as::<u16>(), crate::Vec2::new(u16::MAX, 21));
+        assert_eq!(err.overflowing_as::<u16>(), (err.wrapping_as(), true));
+        assert_eq!(ok.overflowing_as::<u16>(), (ok.unwrapped_as(), false));
+    }
     macro_rules! test_vec_t {
         (repr_c $Vec:ident<$T:ident>) => {
 


### PR DESCRIPTION
[`az`](https://crates.io/crates/az) provides a variety of conversion traits which number types can implement. In particular, `fixed` implements those traits.

We could consider introducing a method for each of the conversions.
Not to avoid bringing the traits into scope. To annotate the destination type of casts, you need to do `vec.checked_as::<Vec2<u16>>()?`. With a method, we could remove the `Vec2<_>` and condense it down to `vec.checked_as<u16>()?>()`.

I wasn't sure which version I should use, so I used the first one which offers all of its traits, which is also compatible with the newest release version-wise.

More context in #88 