### PR TITLE
Implement ``bytemuck`` traits for other common types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ approx = { version = "0.5.0", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 num-integer = { version = "0.1.44", default-features = false }
 image = { version = "0.23", optional = true, default-features = false }
-serde = { version = "1.0.105", optional = true, default-features = false, features = ["derive"] }
+serde = { version = "1.0.171", optional = true, default-features = false, features = ["derive"] }
 mint = { version = "0.5.4", optional = true }
 bytemuck = { version = "1.7.2", optional = true }
 # clippy = { version = "0.0.166", optional = true }

--- a/src/mat.rs
+++ b/src/mat.rs
@@ -3195,6 +3195,24 @@ macro_rules! mat_impl_mat4 {
                 }
             }
         } */
+
+        #[cfg(feature = "bytemuck")]
+        unsafe impl<T> bytemuck::Zeroable for Mat4<T> where T: bytemuck::Zeroable {
+            fn zeroed() -> Self {
+                // I know for a fact there's macro magic to make it work in a single line
+                Self::new(
+                    T::zeroed(), T::zeroed(), T::zeroed(), T::zeroed(),
+                    T::zeroed(), T::zeroed(), T::zeroed(), T::zeroed(),
+                    T::zeroed(), T::zeroed(), T::zeroed(), T::zeroed(),
+                    T::zeroed(), T::zeroed(), T::zeroed(), T::zeroed()
+                )
+            }
+        }
+
+        #[cfg(feature = "bytemuck")]
+        unsafe impl<T> bytemuck::Pod for Mat4<T> where T: bytemuck::Pod {
+            // Nothing here
+        }
     };
 }
 

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -6,6 +6,9 @@ use crate::ops::*;
 use std::ops::Add;
 use std::ops::*;
 
+#[cfg(feature = "bytemuck")]
+use crate::bytemuck;
+
 macro_rules! impl_mul_by_vec {
     ($Vec3:ident $Vec4:ident) => {
         /// 3D vectors can be rotated by being premultiplied by a quaternion, **assuming the
@@ -733,6 +736,24 @@ macro_rules! quaternion_complete_mod {
                     && T::relative_eq(&self.z, &other.z, epsilon, max_relative)
             }
         }
+
+        #[cfg(feature = "bytemuck")]
+        unsafe impl<T> bytemuck::Zeroable for Quaternion<T> where T: bytemuck::Zeroable, Vec4<T>: bytemuck::Zeroable {
+            fn zeroed() -> Self {
+                Self {
+                    x: T::zeroed(),
+                    y: T::zeroed(),
+                    z: T::zeroed(),
+                    w: T::zeroed(),
+                }
+            }
+        }
+
+        #[cfg(feature = "bytemuck")]
+        unsafe impl<T> bytemuck::Pod for Mat4<T> where T: bytemuck::Pod {
+            // Nothing here
+        }
+
     };
 }
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -3807,6 +3807,14 @@ mod tests {
                 assert_eq!((2 as $T) + v, v + (2 as $T));
             }
         };
+        (repr_simd_padding $Vec:ident<$T:ident>) => {
+            #[test]
+            fn test_simd_padding() {
+                let count = $Vec::<$T>::ELEM_COUNT;
+                let elem_size = std::mem::size_of::<$T>();
+                assert_eq!(std::mem::size_of::<$Vec<$T>>(), count * elem_size);
+            }
+        };
     }
     macro_rules! for_each_type {
         ($vec:ident $Vec:ident $($T:ident)+) => {
@@ -3829,6 +3837,7 @@ mod tests {
                         use $crate::vec::repr_simd::$Vec;
                         test_vec_t!{repr_simd $Vec<$T>}
                         test_vec_t!{repr_simd_except_bool $Vec<$T>}
+                        test_vec_t!{repr_simd_padding $Vec<$T>}
                     })+
                     mod bool {
                         use $crate::vec::repr_simd::$Vec;


### PR DESCRIPTION
Implemented ``Zeroable`` and ``Pod`` for all ``Vec<T>`` types and their variants (simd and repr_c), ``Mat4<T>``s, and for ``Quaternion``